### PR TITLE
Remove wdir + a few minor cleanups

### DIFF
--- a/output.py
+++ b/output.py
@@ -160,7 +160,7 @@ def text(
     # Print if requested.
     if output_method == "PRINT":
         print(out)
-    
+
     # two possible save methods, if any are supplied.
     if save_method == "SINGLE":
         filename = os.path.join(save_loc, "ThatChordTemp.txt")
@@ -170,6 +170,9 @@ def text(
     if save_method == "SINGLE" or save_method == "LIBRARY":
         try:
             with open(filename, "w") as f:
+                # Create the folder if it doesn't exist
+                if not os.path.isdir(save_loc):
+                    os.mkdir(save_loc)
                 f.write(out)
         except FileNotFoundError:
             err("file not found")
@@ -372,12 +375,13 @@ def img(
     
     # two possible save methods, if any are supplied.
     if save_method == "SINGLE":
-        filename = save_loc + "ThatChordTemp.png"
+        filename = os.path.join(save_loc, "ThatChordTemp.png")
     elif save_method == "LIBRARY":
-        filename = save_loc + "ThatChord" + name + ".png"
+        filename = os.path.join(save_loc, "ThatChord" + name + ".png")
         
     if save_method == "SINGLE" or save_method == "LIBRARY":
         try:
+            # create the folder if it doesn't exist
             if not os.path.isdir(save_loc):
                 os.mkdir(save_loc)
             img.save(filename)

--- a/output.py
+++ b/output.py
@@ -15,7 +15,7 @@
 ###############################################################################
 ###############################################################################
 
-
+import os
 # import error messages
 from errors import err
 
@@ -40,7 +40,7 @@ def text(
          # input/output arguments, will be passed as **kwioargs
          output_method = "PRINT",
          save_method = "NONE",
-         save_loc = "diagrams/",
+         save_loc = "diagrams",
         ):
     
     """
@@ -62,7 +62,7 @@ def text(
     
     muted is the mark at the top of a muted string.
     """
-    
+
     frets = frets_in.copy()
     if left:
         frets.reverse()
@@ -163,21 +163,19 @@ def text(
     
     # two possible save methods, if any are supplied.
     if save_method == "SINGLE":
-        filename = save_loc + "ThatChordTemp.txt"
-    if save_method == "LIBRARY":
-        filename = save_loc + "ThatChord" + name + ".txt"
+        filename = os.path.join(save_loc, "ThatChordTemp.txt")
+    elif save_method == "LIBRARY":
+        filename = os.path.join(save_loc, "ThatChord" + name + ".txt")
         
     if save_method == "SINGLE" or save_method == "LIBRARY":
         try:
-            f = open(filename, "w")
+            with open(filename, "w") as f:
+                f.write(out)
         except FileNotFoundError:
             err("file not found")
-        f.write(out)
-        f.close()
     
     # If asked to splash, do so now that the file is saved.
     if output_method == "SPLASH":
-        import os
         os.system("open " + filename)
 
 
@@ -375,11 +373,13 @@ def img(
     # two possible save methods, if any are supplied.
     if save_method == "SINGLE":
         filename = save_loc + "ThatChordTemp.png"
-    if save_method == "LIBRARY":
+    elif save_method == "LIBRARY":
         filename = save_loc + "ThatChord" + name + ".png"
         
     if save_method == "SINGLE" or save_method == "LIBRARY":
         try:
+            if not os.path.isdir(save_loc):
+                os.mkdir(save_loc)
             img.save(filename)
         except OSError:
             err("file not found")

--- a/output.py
+++ b/output.py
@@ -168,12 +168,14 @@ def text(
         filename = os.path.join(save_loc, "ThatChord" + name + ".txt")
         
     if save_method == "SINGLE" or save_method == "LIBRARY":
+
         try:
+            if not os.path.isdir(save_loc):
+                os.makedirs(save_loc)
             with open(filename, "w") as f:
-                # Create the folder if it doesn't exist
-                if not os.path.isdir(save_loc):
-                    os.makedirs(save_loc)
                 f.write(out)
+        except OSError:
+            err("file not found")
         except FileNotFoundError:
             err("file not found")
     

--- a/output.py
+++ b/output.py
@@ -172,7 +172,7 @@ def text(
             with open(filename, "w") as f:
                 # Create the folder if it doesn't exist
                 if not os.path.isdir(save_loc):
-                    os.mkdir(save_loc)
+                    os.makedirs(save_loc)
                 f.write(out)
         except FileNotFoundError:
             err("file not found")
@@ -383,7 +383,7 @@ def img(
         try:
             # create the folder if it doesn't exist
             if not os.path.isdir(save_loc):
-                os.mkdir(save_loc)
+                os.makedirs(save_loc)
             img.save(filename)
         except OSError:
             err("file not found")

--- a/settings.py
+++ b/settings.py
@@ -80,12 +80,14 @@ output_method  = "SPLASH"
 # --------------------------------------------------------------------------- #
 save_method = "SINGLE"
 # --------------------------------------------------------------------------- #
-# files are saved to the following directory. Don't forget to add a slash.
-# recommended is to save in a dedicated "diagrams/" folder inside the ThatChord
+# files are saved to the following directory.
+# recommended is to save in a dedicated "diagrams" folder inside the ThatChord
 # folder.
 # DANGER: SAVING MAY OVERWRITE LOCAL FILES. FILENAMES CONTAIN "THATCHORD" TO
 # AVOID CLASHES WITH UNRELATED FILES.
-save_loc = "diagrams"
+# --------------------------------------------------------------------------- #
+save_loc = "~/Documents/ThatChord/diagrams"
+# --------------------------------------------------------------------------- #
 
 
 # GRAPHICAL PARAMETERS HERE. A number of drawing options are available. See

--- a/settings.py
+++ b/settings.py
@@ -143,6 +143,7 @@ top = True
 
 
 from errors import err
+import os
 
 if instrument_preset[-2:] == "-L":
     left = True
@@ -331,5 +332,5 @@ kwgrargs = {
 kwioargs = {
         "output_method" : output_method,
         "save_method"   : save_method,
-        "save_loc"      : save_loc
+        "save_loc"      : os.path.expanduser(save_loc)
         }

--- a/settings.py
+++ b/settings.py
@@ -85,7 +85,7 @@ save_method = "SINGLE"
 # folder.
 # DANGER: SAVING MAY OVERWRITE LOCAL FILES. FILENAMES CONTAIN "THATCHORD" TO
 # AVOID CLASHES WITH UNRELATED FILES.
-save_loc = "diagrams/"
+save_loc = "diagrams"
 
 
 # GRAPHICAL PARAMETERS HERE. A number of drawing options are available. See

--- a/thatchord.py
+++ b/thatchord.py
@@ -30,14 +30,6 @@ request =                        "Gadd9"
 # --------------------------------------------------------------------------- #
 
 
-############            SET YOUR WORKING DIRECTORY HERE            ############
-#####                 recommended: "~/Documents/ThatChord"                #####
-
-# --------------------------------------------------------------------------- #
-wdir =                     "~/Documents/ThatChord"
-# --------------------------------------------------------------------------- #
-
-
 
 
 
@@ -72,10 +64,6 @@ wdir =                     "~/Documents/ThatChord"
 
 # change current directory
 import os
-os.chdir(os.path.expanduser(wdir))
-
-# Load settings
-exec(open("settings.py").read())
 
 # Load other files
 import interpret
@@ -83,18 +71,22 @@ import find
 import rank
 import output
 import custom
+import settings
+from errors import err
 
 # First, figure out what the request is.
-if input_type == "CONSOLE":
+if settings.input_type == "CONSOLE":
     request = input("Enter request here: ")
-if input_type == "TERMINAL":
+elif settings.input_type == "TERMINAL":
     import sys
     request = sys.argv[1]
 
 # Special inputs here:
 if request == "SETTINGS":
     # Typing SETTINGS opens the settings file.
-    os.system("open settings.py")
+    script_directory = os.path.dirname(os.path.realpath(__file__))
+    settings_path = os.path.join(script_directory, "settings.py")
+    os.system("open " + settings_path)
     exit()
 
 # Check whether a specific position in the list was requested. If not, 0 is
@@ -128,31 +120,31 @@ else:
     filename = request
 
 # Find the list of chords.
-options = find.find(chord, tuning, nfrets, stringstarts, nmute, important)
+options = find.find(chord, settings.tuning, settings.nfrets, settings.stringstarts, settings.nmute, settings.important)
 
 # Sort the options using rank
-options.sort(key = lambda x : rank.rank(x, chord, tuning, order, ranks, stringstarts))
+options.sort(key = lambda x : rank.rank(x, chord, settings.tuning, settings.order, settings.ranks, settings.stringstarts))
 
 # Check the requested option is not too big
 if listpos >= len(options):
     err(16)
 
 # figure out what the output format is
-if output_format == "TEXT":
+if settings.output_format == "TEXT":
     output.text(
             options[listpos],
             name = filename,
             title = title,
-            **kwgrargs,
-            **kwioargs
+            **settings.kwgrargs,
+            **settings.kwioargs
             )
 
 # TODO no options for where to put title yet
-if output_format == "PNG":
+elif settings.output_format == "PNG":
     output.img(
             options[listpos],
             name = filename,
             title = title,
-            **kwgrargs,
-            **kwioargs
+            **settings.kwgrargs,
+            **settings.kwioargs
             )


### PR DESCRIPTION
This PR changes the following:

- Removes the `wdir` variable. This changes the behaviour so that the files are placed in the save_loc folder relative to where the user is running the program from, or in the specified folder if an absolute path is provided.
- Creates the specified folder if it doesn't already exist.
- Imports the settings file with a normal import statement, rather than using exec. This provides better encapsulation and makes it easier for tooling to find the variables referenced.