### PR TITLE
Import settings via YAML file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ install:
   - python3 -m pip install --upgrade pip
   - python3 -m pip install --upgrade Pillow
   - python3 -m pip install --upgrade pytest
+  - python3 -m pip install --upgrade pyyaml
 script: pytest

--- a/custom.py
+++ b/custom.py
@@ -34,7 +34,7 @@ def pm(s):
         return + 1
     return 0
 
-def interpret(request):
+def interpret(request, remove_duplicates = True):
     # make a copy of request which we chop notes off
     rc = request
     # initialise empty request. We will fill this note by note
@@ -58,12 +58,15 @@ def interpret(request):
         m = re.match(structure, rc)
     
     # now remove duplicates but maintain order.
-    seen = set()
-    out2 = []
-    for note in out:
-        if not note in seen:
-            seen.add(note)
-            out2.append(note)
+    if remove_duplicates:
+        seen = set()
+        out2 = []
+        for note in out:
+            if not note in seen:
+                seen.add(note)
+                out2.append(note)
+    else:
+        out2 = out.copy()
 
     if out2 == []:
         err(13)

--- a/errors.py
+++ b/errors.py
@@ -20,7 +20,7 @@ class ChordError(Exception):
 def err(reason):
     
     # REASON 1: INVALID INPUT
-    if reason == "input" or reason == 1:
+    if reason in ("input", 1):
         out = """Invalid chord structure: try a chord of the form """         \
             + """WXYZ", where:\n- W is a letter A-G possibly followed """     \
             + """by "b"or "#";\n- (optional) X is a chord quality, e.g. """   \
@@ -30,13 +30,13 @@ def err(reason):
         raise ChordError(out)
     
     # REASON 2: INVALID ALTERATION NUMBER
-    if reason == "alteration" or reason == 2:
+    if reason in ("alteration", 2):
         out = """Invalid alteration: you can alter the numbers 1, 2, 3, 4, """\
             + """5, 6, 7, 9, 11, 13 only."""
         raise ChordError(out)
     
     # REASON 3: UNRECOGNISED CHORD QUALITY
-    if reason == "quality" or reason == 3:
+    if reason in ("quality", 3):
         import dicts
         out = """Unrecognised chord quality. Currently supported chord """    \
             + """qualities are: """ + str(list(dicts.qualities.keys()))       \
@@ -45,7 +45,7 @@ def err(reason):
         raise ChordError(out)
         
     # REASON 4 (FERMAT'S ERROR): MARGIN TOO SMALL TO PRINT LINE NUMBER
-    if reason == "fermat" or reason == 4:
+    if reason in ("fermat", 4):
         out = """In attempting to print a chord, one line number to be """    \
             + """displayed was too long compared to the default margin size"""\
             + """. Ensure ThatChord is not printing chords absurdly high """  \
@@ -54,7 +54,7 @@ def err(reason):
         raise ChordError(out)
     
     # REASON 5: TOO FEW FRETS FOR ANY POSSIBILITIES
-    if reason == "frets" or reason == 5:
+    if reason in ("frets", 5):
         out = """The number of frets is too low for one of your """           \
             + """instrument strings to have any valid positions. Try """      \
             + """changing the number of frets, changing the chord, or """     \
@@ -62,7 +62,7 @@ def err(reason):
         raise ChordError(out)
         
     # REASON 6: NO CHORDS FOUND
-    if reason == "nosols" or reason == 6:
+    if reason in ("nosols", 6):
         out = """There are no ways of playing the requested chord on this """ \
             + """instrument, though your chord was correctly understood. """  \
             + """Try increasing the number of frets or reducing the number """\
@@ -70,37 +70,37 @@ def err(reason):
         raise ChordError(out)
     
     # REASON 7: INVALID INPUT TYPE
-    if reason == "input type" or reason == 7:
+    if reason in ("input type", 7):
         out = """Invalid input type: in the settings file, please set the """ \
             + """variable input_type to be DIRECT, TERMINAL or CONSOLE."""
         raise ChordError(out)
     
     # REASON 8: INVALID OUTPUT FORMAT
-    if reason == "output format" or reason == 8:
+    if reason in ("output format", 8):
         out = """Invalid output format: in the settings file, please set """  \
             + """the variable output_format to be TEXT or PNG."""
         raise ChordError(out)
     
     # REASON 9: INVALID OUTPUT METHOD
-    if reason == "output method" or reason == 9:
+    if reason in ("output method", 9):
         out = """Invalid output method: in the settings file, please set """  \
             + """the variable output_method to be PRINT, SPLASH or NONE."""
         raise ChordError(out)
     
     # REASON 10: INVALID SAVE METHOD
-    if reason == "save method" or reason == 10:
+    if reason in ("save method", 10):
         out = """Invalid save method: in the settings file, please set the """\
             + """variable save_method to be SINGLE, LIBRARY or NONE."""
         raise ChordError(out)
     
     # REASON 11: INCOMPATIBLE OUTPUT SETTINGS
-    if reason == "incompatible output" or reason == 11:
+    if reason in ("incompatible output", 11):
         out = """You have chosen incompatible values of output_format and """ \
             + """output_method. See settings.py to correct this."""
         raise ChordError(out)
     
     # REASON 12: SAVE DIRECTORY DOESN'T EXIST
-    if reason == "file not found" or reason == 12:
+    if reason in ("file not found", 12):
         out = """The output location could not be found. If you have not """  \
             + """tweaked the settings too much, this can probably be fixed """\
             + """by creating a new folder inside the ThatChord folder """     \
@@ -110,7 +110,7 @@ def err(reason):
         raise ChordError(out)
     
     # REASON 13: CUSTOM INPUT NOT RECOGNISED
-    if reason == "custom" or reason == 13:
+    if reason in ("custom", 13):
         out = """Custom input not recongised. To enter a chord note by note"""\
             + """, type "CUSTOM" followed by a list of notes separated by """ \
             + """spaces or commas. Notes can be entered as e.g. 'C#', 'G', """\
@@ -119,7 +119,7 @@ def err(reason):
         raise ChordError(out)
     
     # REASON 14: TOO MANY COLONS IN INPUT
-    if reason == "colons" or reason == 14:
+    if reason in ("colons", 14):
         out = """There are too many colons in your input. Adding a ":" at """ \
             + """the end of your chord request requests a specific index of"""\
             + """ chord in the list of possibilities. There must be at most"""\
@@ -127,7 +127,7 @@ def err(reason):
         raise ChordError(out)
     
     # REASON 15: CANNOT UNDERSTAND LIST INDEX REQUESTED
-    if reason == "aftercolon" or reason == 15:
+    if reason in ("aftercolon", 15):
         out = """You have requested a specific index of chord in the list """ \
             + """of possibilities by using a colon but I don't understand """ \
             + """what index this is. Please follow a colon simply by a """    \
@@ -136,32 +136,32 @@ def err(reason):
         raise ChordError(out)
     
     # REASON 16: LIST INDEX REQUESTED TOO HIGH
-    if reason == "fewoptions" or reason == 16:
+    if reason in ("fewoptions", 16):
         out = """You have requested a solution number which is greater than"""\
             + """ the number of solutions found. Please request a lower """   \
             + """index after the colon."""
         raise ChordError(out)
     
     # REASON 17: LISTS IN SETTINGS NOT OF SAME LENGTH
-    if reason == "lenlists" or reason == 17:
+    if reason in ("lenlists", 17):
         out = """In the settings file, please ensure that the variables """   \
             + """"tuning" and "order" have the same length."""
         raise ChordError(out)
     
     # REASON 18: STRINGSTARTS IS TOO SHORT
-    if reason == "stringstarts" or reason == 18:
+    if reason in ("stringstarts", 18):
         out = """In the settings file, please ensure that the variable """    \
             + """"stringstarts" is at least as long as the number of frets."""
         raise ChordError(out)
     
     # REASON 19: SETTINGS YML FILE NOT FOUND
-    if reason == "settingsnotfound" or reason == 19:
+    if reason in ("settingsnotfound", 19):
         out = """Could not find the settings.yml file. Please ensure that a"""\
             + """ file with that name is in your ThatChord folder."""
         raise ChordError(out)
     
     # REASON 20: SETTINGS MISSING
-    if reason == "settingsmissing" or reason == 20:
+    if reason in ("settingsmissing", 20):
         out = """Some bullet points are missing from the settings.yml file."""\
             + """ Please ensure it contains points: presets; input; output;"""\
             + """ saving; custom_instrument; custom_ranking; graphical_p"""   \

--- a/errors.py
+++ b/errors.py
@@ -114,7 +114,8 @@ def err(reason):
         out = """Custom input not recongised. To enter a chord note by note"""\
             + """, type "CUSTOM" followed by a list of notes separated by """ \
             + """spaces or commas. Notes can be entered as e.g. 'C#', 'G', """\
-            + """'Bb', or as numbers 0-11 (0=C, 1=C#, ...)"""
+            + """'Bb', or as numbers 0-11 (0=C, 1=C#, ...).\nIt may also be"""\
+            + """ that your custom tuning contains no notes."""
         raise ChordError(out)
     
     # REASON 14: TOO MANY COLONS IN INPUT
@@ -151,6 +152,20 @@ def err(reason):
     if reason == "stringstarts" or reason == 18:
         out = """In the settings file, please ensure that the variable """    \
             + """"stringstarts" is at least as long as the number of frets."""
+        raise ChordError(out)
+    
+    # REASON 19: SETTINGS YML FILE NOT FOUND
+    if reason == "settingsnotfound" or reason == 19:
+        out = """Could not find the settings.yml file. Please ensure that a"""\
+            + """ file with that name is in your ThatChord folder."""
+        raise ChordError(out)
+    
+    # REASON 20: SETTINGS MISSING
+    if reason == "settingsmissing" or reason == 20:
+        out = """Some bullet points are missing from the settings.yml file."""\
+            + """ Please ensure it contains points: presets; input; output;"""\
+            + """ saving; custom_instrument; custom_ranking; graphical_p"""   \
+            + """arameters."""
         raise ChordError(out)
     
     raise ChordError(str(reason))

--- a/output.py
+++ b/output.py
@@ -182,6 +182,10 @@ def text(
     # If asked to splash, do so now that the file is saved.
     if output_method == "SPLASH":
         os.system("open " + filename)
+    
+    # If not asked to do anything, return value.
+    if output_method == "NONE":
+        return out
 
 
 def img(

--- a/settings.py
+++ b/settings.py
@@ -110,7 +110,6 @@ def get_settings(settingsfile      = "settings.yml",
     
     script_directory = os.path.dirname(os.path.realpath(__file__))
     settings_path = os.path.join(script_directory, settingsfile)
-    print(settings_path)
     try:
         with open(settings_path, "r") as file:
             content = yaml.load(file, Loader=yaml.FullLoader)

--- a/settings.py
+++ b/settings.py
@@ -3,12 +3,11 @@
 ##                                                                           ##
 ##  THATCHORD BY TOM CONTI-LESLIE                               settings.py  ##
 ##                                                                           ##
-##  This file allows the user to specify a number of preferences. The first  ##
-##  section is for instrument properties. Presets are available, always      ##
-##  written in capital letters. When a preset is not recognised, the values  ##
-##  underneath are taken.                                                    ##
-##  The settings after that are for input/output modes, and graphical        ##
-##  parameters for the output.                                               ##
+##  This file defines a function which takes in a settings file location     ##
+##  and potential manual settings assignments, then combines these settings  ##
+##  and overwrites manual assignments with any presets that are defined.     ##
+##  Note that manual assignments in the function's variables overwrite       ##
+##  assignments in the settings file.                                        ##
 ##                                                                           ##
 ##                                                                           ##
 ##  License: CC BY-SA 4.0                                                    ##
@@ -18,319 +17,444 @@
 ###############################################################################
 ###############################################################################
 
-# IMPORTANT: PRESETS SURROUNDED BY QUOTATION MARKS ARE ALWAYS IN ALL CAPS.
-
-
-# CHOOSE YOUR INSTRUMENT HERE, OR SET TO THE EMPTY STRING TO USE SETTINGS
-# UNDERNEATH.
-# --------------------------------------------------------------------------- #
-instrument_preset = "UKULELE"
-# --------------------------------------------------------------------------- #
-
-# If the preset is unrecognised, the following values are used.
-# See find.py to see what they do.
-tuning       = [7, 0, 4, 9]
-nfrets       = 12
-nmute        = 0
-important    = 4
-order        = [2, 0, 1, 3]
-left         = False
-stringstarts = [0, 0, 0, 0]
-
-
-# CHOOSE YOUR RANKING COEFFICIENT PRESET HERE, OR SET TO EMPTY TO USE SETTINGS
-# UNDERNEATH.
-# --------------------------------------------------------------------------- #
-ranking_preset = "UKULELE"
-# --------------------------------------------------------------------------- #
-
-# If the preset is unrecognised, the following coefficients are used.
-ranks = [1, 2, 3, 1, 0, 0, 0, 0, 0]
-
-
-# CHOOSE YOUR INPUT MODE HERE. OPTIONS: DIRECT/TERMINAL/CONSOLE.
-# DIRECT takes the contents of the string in the main file.
-# TERMINAL assumes you are running python3 from your terminal and have
-# written the chord name after the filename.
-# CONSOLE assumes you are using a Python console and will ask for input.
-# --------------------------------------------------------------------------- #
-input_type = "TERMINAL"
-# --------------------------------------------------------------------------- #
-
-
-# CHOOSE YOUR OUTPUT FORMAT HERE. OPTIONS: TEXT/PNG.
-# --------------------------------------------------------------------------- #
-output_format = "PNG"
-# --------------------------------------------------------------------------- #
-
-
-# CHOOSE YOUR OUTPUT METHOD HERE. OPTIONS:
-# PRINT: only available with TEXT format. Prints to console.
-# SPLASH: Opens a temp file with the image.
-# NONE: do nothing with the output. The file will still be saved if you want.
-# --------------------------------------------------------------------------- #
-output_method  = "SPLASH"
-# --------------------------------------------------------------------------- #
-
-
-# CHOOSE YOUR SAVE METHOD HERE. OPTIONS:
-# SINGLE: saves one file in specified location, overwriting any others
-# LIBRARY: makes a (semi)unique filename to avoid overwriting.
-# NONE: don't save any files.
-# --------------------------------------------------------------------------- #
-save_method = "SINGLE"
-# --------------------------------------------------------------------------- #
-# files are saved to the following directory.
-# recommended is to save in a dedicated "diagrams" folder inside the ThatChord
-# folder.
-# DANGER: SAVING MAY OVERWRITE LOCAL FILES. FILENAMES CONTAIN "THATCHORD" TO
-# AVOID CLASHES WITH UNRELATED FILES.
-# --------------------------------------------------------------------------- #
-save_loc = "~/Documents/ThatChord/diagrams"
-# --------------------------------------------------------------------------- #
-
-
-# GRAPHICAL PARAMETERS HERE. A number of drawing options are available. See
-# what they do in output.py.
-height = 5
-margin = 3
-head   = "="
-string = "|"
-press  = "O"
-muted  = "x"
-top = True
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-###############################################################################
-###############################################################################
-####          DO   NOT   CHANGE   ANYTHING   PAST   THIS   POINT           ####
-###############################################################################
-###############################################################################
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-from errors import err
-import os
-
-if instrument_preset[-2:] == "-L":
-    left = True
-    instrument_preset = instrument_preset[0:-2]
-
-
-# DEFINE INSTRUMENT PRESETS HERE
-if instrument_preset in ["UKULELE", "UKULELE-SOPRANO", "UKULELE-REENTRANT",   \
-                         "UKULELE-SOPRANO-REENTRANT"]:
-    tuning    = [7, 0, 4, 9]
-    nfrets    = 12
-    nmute     = 0
-    important = 4
-    order     = [2, 0, 1, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-D", "UKULELE-SOPRANO-D",                    \
-                         "UKULELE-D-REENTRANT", "UKULELE-SOPRANO-D-REENTRANT"]:
-    # Ukulele in D tuning: aDF#B
-    tuning    = [9, 2, 6, 11]
-    nfrets    = 12
-    nmute     = 0
-    important = 4
-    order     = [2, 0, 1, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-CONCERT", "UKULELE-CONCERT-REENTRANT"]:
-    tuning    = [7, 0, 4, 9]
-    nfrets    = 15
-    nmute     = 0
-    important = 4
-    order     = [2, 0, 1, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-CONCERT-LINEAR"]:
-    tuning    = [7, 0, 4, 9]
-    nfrets    = 15
-    nmute     = 0
-    important = 4
-    order     = [0, 1, 2, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-TENOR", "UKULELE-TENOR-REENTRANT"]:
-    tuning    = [7, 0, 4, 9]
-    nfrets    = 15
-    nmute     = 0
-    important = 4
-    order     = [2, 0, 1, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-TENOR-LINEAR"]:
-    tuning    = [7, 0, 4, 9]
-    nfrets    = 15
-    nmute     = 0
-    important = 4
-    order     = [0, 1, 2, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-TENOR-CHICAGO",                             \
-                         "UKULELE-TENOR-CHICAGO-REENTRANT"]:
-    tuning    = [2, 7, 11, 4]
-    nfrets    = 15
-    nmute     = 0
-    important = 4
-    order     = [2, 0, 1, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-TENOR-CHICAGO-LINEAR"]:
-    tuning    = [2, 7, 11, 4]
-    nfrets    = 15
-    nmute     = 0
-    important = 4
-    order     = [0, 1, 2, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-BARITONE", "UKULELE-BARITONE-REENTRANT"]:
-    tuning    = [7, 0, 4, 9]
-    nfrets    = 19
-    nmute     = 0
-    important = 4
-    order     = [2, 0, 1, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-BARITONE-LINEAR"]:
-    tuning    = [7, 0, 4, 9]
-    nfrets    = 19
-    nmute     = 0
-    important = 4
-    order     = [0, 1, 2, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-BARITONE-CHICAGO",                          \
-                         "UKULELE-BARITONE-CHICAGO-REENTRANT"]:
-    tuning    = [2, 7, 11, 4]
-    nfrets    = 19
-    nmute     = 0
-    important = 4
-    order     = [2, 0, 1, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["UKULELE-BARITONE-CHICAGO-LINEAR"]:
-    tuning    = [2, 7, 11, 4]
-    nfrets    = 19
-    nmute     = 0
-    important = 4
-    order     = [0, 1, 2, 3]
-    stringstarts = [0, 0, 0, 0]
-
-if instrument_preset in ["GUITAR"]:
-    tuning    = [4, 9, 2, 7, 11, 4]
-    nfrets    = 19
-    nmute     = 2
-    important = 6
-    order     = [0, 1, 2, 3, 4, 5]
-    stringstarts = [0, 0, 0, 0, 0, 0]
-
-if instrument_preset in ["BANJO"]:
-    tuning       = [7, 2, 7, 11, 2]
-    nfrets       = 15
-    nmute        = 1
-    important    = 3 # usually not playing complex chords
-    order        = [4, 0, 1, 2, 3]
-    stringstarts = [5, 0, 0, 0, 0]
-    height       = 6 # so that there's space for the additional string
+def get_settings(settingsfile      = "settings.yml",
+                 # NB.: settingsfile is relative to ThatChord directory.
+                 instrument_preset = None,
+                 ranking_preset    = None,
+                 tuning            = None,
+                 nfrets            = None,
+                 nmute             = None,
+                 important         = None,
+                 order             = None,
+                 left              = None,
+                 stringstarts      = None,
+                 ranks             = None,
+                 input_type        = None,
+                 output_format     = None,
+                 output_method     = None,
+                 save_method       = None,
+                 save_loc          = None,
+                 height            = None,
+                 margin            = None,
+                 head              = None,
+                 string            = None,
+                 press             = None,
+                 muted             = None,
+                 top               = None,
+                 ):
+
+    # firstly, put the manual assignments aside.
+
+    xinstrument_preset = instrument_preset
+    xranking_preset    = ranking_preset
+    xtuning            = tuning
+    xnfrets            = nfrets
+    xnmute             = nmute
+    ximportant         = important
+    xorder             = order
+    xleft              = left
+    xstringstarts      = stringstarts
+    xranks             = ranks
+    xinput_type        = input_type
+    xoutput_format     = output_format
+    xoutput_method     = output_method
+    xsave_method       = save_method
+    xsave_loc          = save_loc
+    xheight            = height
+    xmargin            = margin
+    xhead              = head
+    xstring            = string
+    xpress             = press
+    xmuted             = muted
+    xtop               = top
+
+
+    # PRIORITY LEVEL 1: default values for all variables.
     
-if instrument_preset in ["SAZ"]:
-    tuning       = [2, 7, 9]
-    nfrets       = 14
+    instrument_preset = "UKULELE"
+    
+    tuning       = [7, 0, 4, 9]
+    nfrets       = 12
     nmute        = 0
-    important    = 3
-    order        = [2, 0, 1]
-    stringstarts = [0, 0, 0]
+    important    = 4
+    order        = [2, 0, 1, 3]
+    left         = False
+    stringstarts = [0, 0, 0, 0]
     
-
-# DEFINE RANKING PRESETS HERE
-if ranking_preset in ["UKULELE"]:
+    ranking_preset = "UKULELE"
+    
     ranks = [1, 2, 3, 1, 0, 0, 0, 0, 0]
-
-if ranking_preset in ["GUITAR"]:
-    ranks = [3, 0, 3, 1, 0, 5, 2, 5, 8]
-
-if ranking_preset in ["BANJO"]:
-    ranks = [2, 1, 3, 0, 1, 0, 3, 2, 1]
-
-
-# SENSE CHECKING FOR I/O FORMATS
-if not input_type in ["DIRECT", "TERMINAL", "CONSOLE"]:
-    err("input type")
-
-if not output_format in ["TEXT", "PNG"]:
-    err("output format")
-
-if not output_method in ["PRINT", "SPLASH", "NONE"]:
-    err("output method")
-
-if not save_method in ["SINGLE", "LIBRARY", "NONE"]:
-    err("save method")
-
-if output_method == "PRINT" and not output_format == "TEXT":
-    err("incompatible output")
     
-if len(tuning) != len(order):
-    err(17)
-
-if len(stringstarts) < len(tuning):
-    err(18)
-
-# CHANGE TUNING TO IMAGINED NECK, FOR STRINGS STARTING HIGHER THAN 0TH FRET
-for i in range(len(tuning)):
-    tuning[i] = (tuning[i] - stringstarts[i]) % 12
-
-# MAKE GRAPHICAL PARAMETERS DICTIONARY
-kwgrargs = {
-        "height"       : height,
-        "margin"       : margin,
-        "head"         : head,
-        "string"       : string,
-        "press"        : press,
-        "muted"        : muted,
-        "left"         : left,
-        "top"          : top,
-        "stringstarts" : stringstarts,
-        }
-
-# MAKE INPUT/OUTPUT PARAMETERS DICTIONARY
-kwioargs = {
-        "output_method" : output_method,
-        "save_method"   : save_method,
-        "save_loc"      : os.path.expanduser(save_loc)
-        }
+    input_type = "TERMINAL"
+    output_format = "PNG"
+    output_method  = "SPLASH"
+    save_method = "SINGLE"
+    save_loc = "~/Documents/ThatChord/diagrams"
+    
+    height = 5
+    margin = 3
+    head   = "="
+    string = "|"
+    press  = "O"
+    muted  = "x"
+    top = True
+    
+    
+    # PRIORITY LEVEL 2: overwrite default values with settings loaded from
+    #                   settings.yml.
+    
+    import yaml
+    import os
+    from errors import err
+    import custom
+    
+    script_directory = os.path.dirname(os.path.realpath(__file__))
+    settings_path = os.path.join(script_directory, settingsfile)
+    print(settings_path)
+    try:
+        with open(settings_path, "r") as file:
+            content = yaml.load(file, Loader=yaml.FullLoader)
+            keys = content.keys()
+            
+            if "presets" in keys:
+                for d in content["presets"]:
+                    if "instrument" in d.keys():
+                        instrument_preset = list(d.values())[0].upper()
+                    if "ranking" in d.keys():
+                        ranking_preset = list(d.values())[0].upper()
+            else:
+                err(20)
+            
+            if "input" in keys:
+                for d in content["input"]:
+                    if "how" in d.keys():
+                        input_type = list(d.values())[0].upper()
+            else:
+                err(20)
+            
+            if "output" in keys:
+                for d in content["output"]:
+                    if "how" in d.keys():
+                        output_method = list(d.values())[0].upper()
+                    if "format" in d.keys():
+                        output_format = list(d.values())[0].upper()
+            else:
+                err(20)
+            
+            if "saving" in keys:
+                for d in content["saving"]:
+                    if "method" in d.keys():
+                        save_method = list(d.values())[0].upper()
+                    if "location" in d.keys():
+                        save_loc = list(d.values())[0]
+            else:
+                err(20)
+            
+            if "custom_instrument" in keys:
+                for d in content["custom_instrument"]:
+                    if "tuning" in d.keys():
+                        tuning = custom.interpret(list(d.values())[0],
+                                                  remove_duplicates = False)
+                    if "nfrets" in d.keys():
+                        nfrets = list(d.values())[0]
+                    if "nmute" in d.keys():
+                        nmute = list(d.values())[0]
+                    if "important" in d.keys():
+                        important = list(d.values())[0]
+                    if "order" in d.keys():
+                        order = list(d.values())[0].copy()
+                    if "handedness" in d.keys():
+                        handedness = list(d.values())[0].upper()
+                        if handedness in ["LEFT", "RIGHT"]:
+                            left = {"LEFT" : True, "RIGHT" : False}[handedness]
+                    if "stringstarts" in d.keys():
+                        stringstarts = list(d.values())[0].copy()
+            else:
+                err(20)
+            
+            if "custom_ranking" in keys:
+                for d in content["custom_ranking"]:
+                    if "ranks" in d.keys():
+                        ranks = list(d.values())[0].copy()
+            else:
+                err(20)
+                
+            if "graphical_parameters" in keys:
+                for d in content["graphical_parameters"]:
+                    if "height" in d.keys():
+                        height = list(d.values())[0]
+                    if "margin" in d.keys():
+                        margin = list(d.values())[0]
+                    if "head" in d.keys():
+                        head = list(d.values())[0]
+                    if "string" in d.keys():
+                        string = list(d.values())[0]
+                    if "press" in d.keys():
+                        press = list(d.values())[0]
+                    if "muted" in d.keys():
+                        muted = list(d.values())[0]
+                    if "title_at_top" in d.keys():
+                        top = list(d.values())[0]
+            else:
+                err(20)
+    except FileNotFoundError:
+        err(19)
+   
+    
+    # PRIORITY LEVEL 3: MANUAL ASSIGNMENTS.
+    
+    if xinstrument_preset:
+        instrument_preset = xinstrument_preset.upper()
+    if xranking_preset:
+        ranking_preset = xranking_preset.upper()
+    if xtuning:
+        tuning = xtuning
+    if xnfrets:
+        nfrets = xnfrets
+    if xnmute:
+        nmute = xnmute
+    if ximportant:
+        important = ximportant
+    if xorder:
+        order = xorder
+    if xleft:
+        left = xleft
+    if xstringstarts:
+        stringstarts = xstringstarts
+    if xranks:
+        ranks = xranks
+    if xinput_type:
+        input_type = xinput_type.upper()
+    if xoutput_format:
+        output_format = xoutput_format.upper()
+    if xoutput_method:
+        output_method = xoutput_method.upper()
+    if xsave_method:
+        save_method = xsave_method.upper()
+    if xsave_loc:
+        save_loc = xsave_loc
+    if xheight:
+        height = xheight
+    if xmargin:
+        margin = xmargin
+    if xhead:
+        head = xhead
+    if xstring:
+        string = xstring
+    if xpress:
+        press = xpress
+    if xmuted:
+        muted = xmuted
+    if xtop:
+        top = xtop
+    
+    
+    # PROCESS VARIABLES HERE.
+    
+    if instrument_preset[-2:] == "-L":
+        left = True
+        instrument_preset = instrument_preset[0:-2]
+    
+    
+    # DEFINE INSTRUMENT PRESETS HERE
+    if instrument_preset in ["UKULELE", "UKULELE-SOPRANO", "UKULELE-REENTRANT",   \
+                             "UKULELE-SOPRANO-REENTRANT"]:
+        tuning    = [7, 0, 4, 9]
+        nfrets    = 12
+        nmute     = 0
+        important = 4
+        order     = [2, 0, 1, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-D", "UKULELE-SOPRANO-D",                    \
+                             "UKULELE-D-REENTRANT", "UKULELE-SOPRANO-D-REENTRANT"]:
+        # Ukulele in D tuning: aDF#B
+        tuning    = [9, 2, 6, 11]
+        nfrets    = 12
+        nmute     = 0
+        important = 4
+        order     = [2, 0, 1, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-CONCERT", "UKULELE-CONCERT-REENTRANT"]:
+        tuning    = [7, 0, 4, 9]
+        nfrets    = 15
+        nmute     = 0
+        important = 4
+        order     = [2, 0, 1, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-CONCERT-LINEAR"]:
+        tuning    = [7, 0, 4, 9]
+        nfrets    = 15
+        nmute     = 0
+        important = 4
+        order     = [0, 1, 2, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-TENOR", "UKULELE-TENOR-REENTRANT"]:
+        tuning    = [7, 0, 4, 9]
+        nfrets    = 15
+        nmute     = 0
+        important = 4
+        order     = [2, 0, 1, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-TENOR-LINEAR"]:
+        tuning    = [7, 0, 4, 9]
+        nfrets    = 15
+        nmute     = 0
+        important = 4
+        order     = [0, 1, 2, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-TENOR-CHICAGO",                             \
+                             "UKULELE-TENOR-CHICAGO-REENTRANT"]:
+        tuning    = [2, 7, 11, 4]
+        nfrets    = 15
+        nmute     = 0
+        important = 4
+        order     = [2, 0, 1, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-TENOR-CHICAGO-LINEAR"]:
+        tuning    = [2, 7, 11, 4]
+        nfrets    = 15
+        nmute     = 0
+        important = 4
+        order     = [0, 1, 2, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-BARITONE", "UKULELE-BARITONE-REENTRANT"]:
+        tuning    = [7, 0, 4, 9]
+        nfrets    = 19
+        nmute     = 0
+        important = 4
+        order     = [2, 0, 1, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-BARITONE-LINEAR"]:
+        tuning    = [7, 0, 4, 9]
+        nfrets    = 19
+        nmute     = 0
+        important = 4
+        order     = [0, 1, 2, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-BARITONE-CHICAGO",                          \
+                             "UKULELE-BARITONE-CHICAGO-REENTRANT"]:
+        tuning    = [2, 7, 11, 4]
+        nfrets    = 19
+        nmute     = 0
+        important = 4
+        order     = [2, 0, 1, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["UKULELE-BARITONE-CHICAGO-LINEAR"]:
+        tuning    = [2, 7, 11, 4]
+        nfrets    = 19
+        nmute     = 0
+        important = 4
+        order     = [0, 1, 2, 3]
+        stringstarts = [0, 0, 0, 0]
+    
+    if instrument_preset in ["GUITAR"]:
+        tuning    = [4, 9, 2, 7, 11, 4]
+        nfrets    = 19
+        nmute     = 2
+        important = 6
+        order     = [0, 1, 2, 3, 4, 5]
+        stringstarts = [0, 0, 0, 0, 0, 0]
+    
+    if instrument_preset in ["BANJO"]:
+        tuning       = [7, 2, 7, 11, 2]
+        nfrets       = 15
+        nmute        = 1
+        important    = 3 # usually not playing complex chords
+        order        = [4, 0, 1, 2, 3]
+        stringstarts = [5, 0, 0, 0, 0]
+        height       = 6 # so that there's space for the additional string
+        
+    if instrument_preset in ["SAZ"]:
+        tuning       = [2, 7, 9]
+        nfrets       = 14
+        nmute        = 0
+        important    = 3
+        order        = [2, 0, 1]
+        stringstarts = [0, 0, 0]
+        
+    
+    # DEFINE RANKING PRESETS HERE
+    if ranking_preset in ["UKULELE"]:
+        ranks = [1, 2, 3, 1, 0, 0, 0, 0, 0]
+    
+    if ranking_preset in ["GUITAR"]:
+        ranks = [3, 0, 3, 1, 0, 5, 2, 5, 8]
+    
+    if ranking_preset in ["BANJO"]:
+        ranks = [2, 1, 3, 0, 1, 0, 3, 2, 1]
+    
+    
+    # SENSE CHECKING FOR I/O FORMATS
+    if not input_type in ["DIRECT", "TERMINAL", "CONSOLE"]:
+        err("input type")
+    
+    if not output_format in ["TEXT", "PNG"]:
+        err("output format")
+    
+    if not output_method in ["PRINT", "SPLASH", "NONE"]:
+        err("output method")
+    
+    if not save_method in ["SINGLE", "LIBRARY", "NONE"]:
+        err("save method")
+    
+    if output_method == "PRINT" and not output_format == "TEXT":
+        err("incompatible output")
+        
+    if len(tuning) != len(order):
+        err(17)
+    
+    if len(stringstarts) < len(tuning):
+        err(18)
+    
+    # CHANGE TUNING TO IMAGINED NECK, FOR STRINGS STARTING HIGHER THAN 0TH FRET
+    for i in range(len(tuning)):
+        tuning[i] = (tuning[i] - stringstarts[i]) % 12
+    
+    # MAKE GRAPHICAL PARAMETERS DICTIONARY - for output functions
+    kwgrargs = {
+            "height"       : height,
+            "margin"       : margin,
+            "head"         : head,
+            "string"       : string,
+            "press"        : press,
+            "muted"        : muted,
+            "left"         : left,
+            "top"          : top,
+            "stringstarts" : stringstarts,
+            }
+    
+    # MAKE INPUT/OUTPUT PARAMETERS DICTIONARY - for output functions
+    kwioargs = {
+            "output_method" : output_method,
+            "save_method"   : save_method,
+            "save_loc"      : os.path.expanduser(save_loc)
+            }
+    
+    # MAKE COMPLETE SETTINGS DICTIONARY - for use in main file
+    settings = {
+            "tuning"        : tuning,
+            "nfrets"        : nfrets,
+            "nmute"         : nmute,
+            "important"     : important,
+            "order"         : order,
+            "left"          : left,
+            "stringstarts"  : stringstarts,
+            "ranks"         : ranks,
+            "input_type"    : input_type,
+            "output_format" : output_format,
+            "output_method" : output_method,
+            "save_method"   : save_method,
+            "save_loc"      : save_loc}
+    
+    return settings, kwgrargs, kwioargs

--- a/settings.yml
+++ b/settings.yml
@@ -1,0 +1,41 @@
+presets:
+  - instrument: ukulele
+  - ranking: ukulele
+
+input:
+  - how: terminal
+
+output:
+  - how: splash
+  - format: png
+
+saving:
+  - method: single
+  - location: ~/Documents/ThatChord/diagrams
+
+
+
+
+# If the instrument preset is not recognised, the settings below are used:
+custom_instrument:
+  - tuning: B B E A
+  - nfrets: 12
+  - nmute: 0
+  - important: 4
+  - order: [2, 0, 1, 3]
+  - handedness: right
+  - stringstarts: [0, 0, 0, 0]
+
+# If the ranking preset is not recognised, the settings below are used:
+custom_ranking:
+  - ranks: [1, 2, 3, 1, 0, 0, 0, 0, 0]
+
+# Graphical parameters here.
+graphical_parameters:
+  - height: 5
+  - margin: 3
+  - head: "="
+  - string: "|"
+  - press: O
+  - muted: x
+  - title_at_top: yes

--- a/settings.yml
+++ b/settings.yml
@@ -18,7 +18,7 @@ saving:
 
 # If the instrument preset is not recognised, the settings below are used:
 custom_instrument:
-  - tuning: B B E A
+  - tuning: G C E A
   - nfrets: 12
   - nmute: 0
   - important: 4

--- a/thatchord.py
+++ b/thatchord.py
@@ -74,18 +74,21 @@ import custom
 import settings
 from errors import err
 
+# Load settings from file. All defaults here so empty input.
+settings, kwgrargs, kwioargs = settings.get_settings()
+
 # First, figure out what the request is.
-if settings.input_type == "CONSOLE":
+if settings["input_type"] == "CONSOLE":
     request = input("Enter request here: ")
-elif settings.input_type == "TERMINAL":
+elif settings["input_type"] == "TERMINAL":
     import sys
     request = sys.argv[1]
 
 # Special inputs here:
-if request == "SETTINGS":
+if request.upper() == "SETTINGS":
     # Typing SETTINGS opens the settings file.
     script_directory = os.path.dirname(os.path.realpath(__file__))
-    settings_path = os.path.join(script_directory, "settings.py")
+    settings_path = os.path.join(script_directory, "settings.yml")
     os.system("open " + settings_path)
     exit()
 
@@ -106,7 +109,7 @@ if ":" in request:
     request = request[:colon_positions[0]]
     
 
-if request[0:6] == "CUSTOM":
+if request[0:6].upper() == "CUSTOM":
     # custom note by note input triggered. Code in "custom.py".
     chord = custom.interpret(request[6:])
     # title removes CUSTOM but adds exclamation mark to indicate custom.
@@ -120,31 +123,31 @@ else:
     filename = request
 
 # Find the list of chords.
-options = find.find(chord, settings.tuning, settings.nfrets, settings.stringstarts, settings.nmute, settings.important)
+options = find.find(chord, settings["tuning"], settings["nfrets"], settings["stringstarts"], settings["nmute"], settings["important"])
 
 # Sort the options using rank
-options.sort(key = lambda x : rank.rank(x, chord, settings.tuning, settings.order, settings.ranks, settings.stringstarts))
+options.sort(key = lambda x : rank.rank(x, chord, settings["tuning"], settings["order"], settings["ranks"], settings["stringstarts"]))
 
 # Check the requested option is not too big
 if listpos >= len(options):
     err(16)
 
 # figure out what the output format is
-if settings.output_format == "TEXT":
+if settings["output_format"] == "TEXT":
     output.text(
             options[listpos],
             name = filename,
             title = title,
-            **settings.kwgrargs,
-            **settings.kwioargs
+            **kwgrargs,
+            **kwioargs
             )
 
 # TODO no options for where to put title yet
-elif settings.output_format == "PNG":
+elif settings["output_format"] == "PNG":
     output.img(
             options[listpos],
             name = filename,
             title = title,
-            **settings.kwgrargs,
-            **settings.kwioargs
+            **kwgrargs,
+            **kwioargs
             )


### PR DESCRIPTION
This PR drastically increases user readability of the settings file. `settings.py` is still an existing file but is not to be modified by the user. Instead, the file `settings.yml` is modified.

Main changes:
- Modify settings in dedicated `settings.yml` file
- `settings.py` now contains the function `get_settings(...)` which loads settings and applies presets in a tiered priority system. Default values of each variable are set (RH soprano GCEA ukulele, terminal splash png) and then overwritten by the contents of the specified settings YAML file. Then, manual variable assignments as function arguments overwrite the YAML settings. Finally, presets are applied and overwrite tuning, ranks, and so on.
- PyYAML must now be installed as a prerequisite.
- More tests have been developed as settings can be more easily manipulated.