### PR TITLE
Fix file splashing on Linux

### DIFF
--- a/output.py
+++ b/output.py
@@ -16,6 +16,7 @@
 ###############################################################################
 
 import os
+import platform # To differentiate between platforms
 # import error messages
 from errors import err
 
@@ -181,7 +182,10 @@ def text(
     
     # If asked to splash, do so now that the file is saved.
     if output_method == "SPLASH":
-        os.system("open " + filename)
+        if platform.system() == "Linux":
+            os.system("xdg-open " + filename)
+        else:
+            os.system("open " + filename)
     
     # If not asked to do anything, return value.
     if output_method == "NONE":

--- a/thatchord.py
+++ b/thatchord.py
@@ -64,6 +64,7 @@ request =                        "Gadd9"
 
 # change current directory
 import os
+import platform # To differentiate between platforms
 
 # Load other files
 import interpret
@@ -140,7 +141,10 @@ if request.upper() == "SETTINGS":
     # Typing SETTINGS opens the settings file.
     script_directory = os.path.dirname(os.path.realpath(__file__))
     settings_path = os.path.join(script_directory, "settings.yml")
-    os.system("open " + settings_path)
+    if platform.system() == "Linux":
+        os.system("xdg-open " + settings_path)
+    else:
+        os.system("open " + settings_path)
     exit()
 
 # Check whether a specific position in the list was requested. If not, 0 is


### PR DESCRIPTION
This PR fixes issue #14 by using a Linux friendly `open` alternative as discussed in the issue.

It also introduces a dependency on `platform` library to help with platform detection but this shouldnt be an issue as it is a standard library.