### PR TITLE
Improves finder speed

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -136,6 +136,8 @@ def err(reason):
         raise ChordError(out)
     
     # REASON 16: LIST INDEX REQUESTED TOO HIGH
+    # N.B. deprecated since faster restructure which, for a too high index,
+    # simply returns the worst we've got.
     if reason in ("fewoptions", 16):
         out = """You have requested a solution number which is greater than"""\
             + """ the number of solutions found. Please request a lower """   \

--- a/find.py
+++ b/find.py
@@ -19,6 +19,9 @@
 # import error messages
 from errors import err
 
+# import ranking functions
+import rank
+
 def increment(maxes, current):
     """
     Helper function for incrementing a list of indices, 'current', by
@@ -35,15 +38,40 @@ def increment(maxes, current):
             return
         current[i] = 0
 
-def find(chord, tuning, nfrets, stringstarts, nmute = 0, important = 0):
+def insert(options, frets, index,
+           # ranking parameters
+           chord = [], tuning = [], order = [], ranks = [], stringstarts = []):
+    """
+    N.B. modifies options in place.
+    Inserts frets into options if the rank of frets is lower than some of the
+    current options. Pushes the worse options out of the list.
+    """
+    # First calculate rank of frets
+    r = rank.rank(frets, chord, tuning, order, ranks, stringstarts)
+    tup = (frets, r)
+    # start at worse end of list, move all the way to where r is in order
+    i = len(options)
+    while i > 0 and r < options[i][1]:
+        i -= 1
+    if len(options) < index - 1:
+        pass
+    
+
+def find(chord, nmute = 0, important = 0, index = 0, nfrets = 12,
+         # Below are ranking args (some are also used for finding)
+         tuning = [], order = [], ranks = [], stringstarts = []):
     """
     This function is called in the main file, thatchord.py.
     
     In this function, all possible fret positions are considered on each string
     and are compiled into 'valids'. All positions which give any note
     in the chord are maintained. This has the disadvantage of considering, e.g.
-    4 copies of C as a valid configuration for the chord C major. The second
-    part of the function filters these out.
+    4 copies of C as a valid configuration for the chord C major.
+    
+    The second part of this function tests every possible configuration and
+    calculates their ranks. It maintains a short list of the best options
+    and then outputs the 'index'th best option found (default 0, i.e. best opt)
+    To avoid recalculating ranks, options are stored as tuples.
     
     chord is a list of notes.
     

--- a/find.py
+++ b/find.py
@@ -22,27 +22,11 @@ from errors import err
 # import ranking functions
 import rank
 
-def increment(maxes, current):
-    """
-    Helper function for incrementing a list of indices, 'current', by
-    increasing the first index if possible, and if not, the next one, etc.
-    (analogous to little endian)
-    
-    The max value for each position is that value in the list 'maxes'.
-    
-    N.B. modifies input 'current'.
-    """
-    for i in range(len(maxes)):
-        if not current[i] == maxes[i] - 1:
-            current[i] += 1
-            return
-        current[i] = 0
-
-def smart_increment(maxes, current, chordset, stringset):
-    # Our current attempt is current. How many notes does that attempt play?
-    # How many notes does our chord need? If there is a gap of k notes between
-    # the two, then we need to change at least the first k counters.
-    k = len(chordset) - len(stringset)
+def smart_increment(maxes, current, remaining):
+    # How many notes is our chord missing? I.e. how big is the remaining set?
+    # If there is a gap of k notes, then we need to change at least the
+    # first k counters.
+    k = len(remaining)
     # if n is 0 or 1 then we don't need to skip anything; just increment
     # normally.
     k = max(k - 1, 0)
@@ -54,9 +38,8 @@ def smart_increment(maxes, current, chordset, stringset):
             current[i] += 1
             break
         current[i] = 0
-    # the counter i will now be set at the number of the rightmost string
-    # changed. Return this to the main loop to update the chordset.
-    return i
+    # the counter i will now be set to the number of strings changed, minus 1
+    return i + 1
             
 
 def insert(options, frets, index, r):
@@ -66,7 +49,7 @@ def insert(options, frets, index, r):
     current options. Pushes the worse options out of the list.
     r is the calculated rank of the option 'frets'.
     """
-    tup = (frets, r)
+    tup = (frets.copy(), r)
     # start at worse end of list, move all the way to where r is in order
     l = len(options)
     i = l
@@ -107,12 +90,19 @@ def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
     important, if nonzero, is the number of notes from the requested chord that
     suffice to "define" the chord.
     """
+    # start by cutting off the chord so that we don't have more distinct notes
+    # than strings to play!
+    if len(chord) > len(tuning):
+        chord = chord[:len(tuning)]
     # define some basic variables. If 0 important notes, we assume the whole
     # chord is needed.
     n = len(tuning)
     valids = []
     if important == 0:
         important = len(chord)
+    # if there are more important notes than strings, cutoff at len(tuning)
+    important = min(important, len(tuning))
+    # create the set of notes we absolutely need in the chord
     chordset = set(chord[:important])
     
     # start by finding all valid positions.
@@ -137,19 +127,31 @@ def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
     current = [0] * n
     options = []
     
+    # initiate our first attempt as the lowest value on all strings.
+    attempt = [valids[i][0] for i in range(n)]
+
     # populate list of note multiplicities. mults[i] is equal to the number of
     # distinct strings playing i.
     mults = [0] * 12
     for i in range(n):
-        pass
+        mults[(tuning[i] + attempt[i]) % 12] += 1
+    # create set of remaining notes: notes that are not played in the current
+    # attempt but needed in the chord.
+    remaining = set()
+    for note in chordset:
+        if mults[note] == 0:
+            remaining.add(note)
     
     # want to iterate until we see 000..0 again
     first_value = [0] * n
     first_time  = True
     
+    # FOR TESTING PURPOSES - function attribute
+    find.count = 0
+    
     while first_time or current != first_value:
         first_time = False
-        attempt = [valids[s][current[s]] for s in range(n)]
+        # attempt = [valids[s][current[s]] for s in range(n)]
         
         # we will assess whether mutes are valid, and then whether sufficiently
         # many notes from the required chord have been hit.
@@ -161,18 +163,46 @@ def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
             if not len(muted) == max(muted) + 1:
                 bool_mute = False
         
-        # Second, check that the attempt covers the important notes
-        notes = [(attempt[i] + tuning[i]) % 12 for i in range(n) if attempt[i] != -1]
-        bool_impo = len(set(chord[:important]) - set(notes)) == 0
+        # Second, check that the attempt covers the important notes.
+        # This is the case iff our remaining set is empty.
+        bool_impo = len(remaining) == 0
         
         # if both conditions are satisfied, store the option.
         if bool_mute and bool_impo:
             r = rank.rank(attempt, chord, tuning, order, ranks, stringstarts)
             insert(options, attempt, index, r)
+            find.count += 1
         
-        # increment the current attempt to the next possibility.
-        increment(maxes, current)
+        # intelligently increment the current attempt to the next possibility.
+        updated = smart_increment(maxes, current, remaining)
+        # we may have changed the values of several strings.
+        # smart_increment has told us how many, and we can update the
+        # remaining set by removing notes that are no longer played now that
+        # we have changed our fret positions.
+        for i in range(updated):
+            # only remove a note if it was not muted.
+            if attempt[i] != -1:
+                old_note = (attempt[i] + tuning[i]) % 12
+                mults[old_note] -= 1
+                if mults[old_note] == 0:
+                    # we have lost all copies of this old note. It is now remaining
+                    remaining.add(old_note)
+            # update that entry of the attempt to the new value
+            attempt[i] = valids[i][current[i]]
+        # now calculate the new notes that are being played as a result of
+        # the incrementation
+        for i in range(updated):
+            # only add notes if the string is not muted
+            if attempt[i] != -1:
+                new_note = (attempt[i] + tuning[i]) % 12
+                mults[new_note] += 1
+                if mults[new_note] == 1:
+                    # then we have just re-introduced this note into our set
+                    # of currently played notes. It is no longer remaining.
+                    remaining.remove(new_note)
     
     # return the worst option in the list of options, which is at the index
     # requested (default is for options to have 1 entry).
+    if options == []:
+        err(16)
     return options[-1][0]

--- a/find.py
+++ b/find.py
@@ -67,7 +67,9 @@ def insert(options, frets, index, r):
 
 def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
          # Below are ranking args (some are also used for finding)
-         tuning = [], order = [], ranks = [], stringstarts = []):
+         tuning = [], order = [], ranks = [], stringstarts = [],
+         # args to activate for testing
+         keep_full_list = False):
     """
     This function is called in the main file, thatchord.py.
     
@@ -148,6 +150,8 @@ def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
     
     # FOR TESTING PURPOSES - function attribute
     find.count = 0
+    if keep_full_list:
+        find.full_list = []
     
     while first_time or current != first_value:
         first_time = False
@@ -171,7 +175,10 @@ def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
         if bool_mute and bool_impo:
             r = rank.rank(attempt, chord, tuning, order, ranks, stringstarts)
             insert(options, attempt, index, r)
+            # FOR TESTING PURPOSES
             find.count += 1
+            if keep_full_list:
+                find.full_list.append(attempt.copy())
         
         # intelligently increment the current attempt to the next possibility.
         updated = smart_increment(maxes, current, remaining)
@@ -184,7 +191,7 @@ def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
             if attempt[i] != -1:
                 old_note = (attempt[i] + tuning[i]) % 12
                 mults[old_note] -= 1
-                if mults[old_note] == 0:
+                if mults[old_note] == 0 and old_note in chordset:
                     # we have lost all copies of this old note. It is now remaining
                     remaining.add(old_note)
             # update that entry of the attempt to the new value
@@ -196,7 +203,7 @@ def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
             if attempt[i] != -1:
                 new_note = (attempt[i] + tuning[i]) % 12
                 mults[new_note] += 1
-                if mults[new_note] == 1:
+                if mults[new_note] == 1 and new_note in chordset:
                     # then we have just re-introduced this note into our set
                     # of currently played notes. It is no longer remaining.
                     remaining.remove(new_note)

--- a/find.py
+++ b/find.py
@@ -38,6 +38,27 @@ def increment(maxes, current):
             return
         current[i] = 0
 
+def smart_increment(maxes, current, chordset, stringset):
+    # Our current attempt is current. How many notes does that attempt play?
+    # How many notes does our chord need? If there is a gap of k notes between
+    # the two, then we need to change at least the first k counters.
+    k = len(chordset) - len(stringset)
+    # if n is 0 or 1 then we don't need to skip anything; just increment
+    # normally.
+    k = max(k - 1, 0)
+    for i in range(k):
+        current[i] = 0
+
+    for i in range(k, len(maxes)):
+        if not current[i] == maxes[i] - 1:
+            current[i] += 1
+            break
+        current[i] = 0
+    # the counter i will now be set at the number of the rightmost string
+    # changed. Return this to the main loop to update the chordset.
+    return i
+            
+
 def insert(options, frets, index, r):
     """
     N.B. modifies options in place.
@@ -92,6 +113,7 @@ def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
     valids = []
     if important == 0:
         important = len(chord)
+    chordset = set(chord[:important])
     
     # start by finding all valid positions.
     for i in range(n):
@@ -114,6 +136,12 @@ def find(chord, nmute = 0, important = 0, index = 1, nfrets = 12,
     # options.
     current = [0] * n
     options = []
+    
+    # populate list of note multiplicities. mults[i] is equal to the number of
+    # distinct strings playing i.
+    mults = [0] * 12
+    for i in range(n):
+        pass
     
     # want to iterate until we see 000..0 again
     first_value = [0] * n

--- a/thatchord.py
+++ b/thatchord.py
@@ -143,9 +143,9 @@ if request.upper() == "SETTINGS":
     os.system("open " + settings_path)
     exit()
 
-# Check whether a specific position in the list was requested. If not, 0 is
-# default.
-listpos = 0
+# Check whether a specific position in the list was requested. If not, 1 is
+# default (best option).
+listpos = 1
 
 if ":" in request:
     colon_positions = [i for i, x in enumerate(request) if x == ":"]
@@ -153,7 +153,7 @@ if ":" in request:
         err("colons")
     # if we made it here then there must be exactly one colon
     try:
-        listpos = int(request[colon_positions[0] + 1:]) - 1
+        listpos = int(request[colon_positions[0] + 1:])
     except ValueError:
         err(15)
     # remove the colon bit from the request
@@ -173,20 +173,22 @@ else:
     title = request
     filename = request
 
-# Find the list of chords.
-options = find.find(chord, tcsettings["tuning"], tcsettings["nfrets"], tcsettings["stringstarts"], tcsettings["nmute"], tcsettings["important"])
+# Find the chord at the requested listpos.
+solution = find.find(chord,
+                     nmute = tcsettings["nmute"],
+                     important = tcsettings["important"],
+                     index = listpos,
+                     nfrets = tcsettings["nfrets"],
+                     tuning = tcsettings["tuning"],
+                     order = tcsettings["order"],
+                     ranks = tcsettings["ranks"],
+                     stringstarts = tcsettings["stringstarts"])
 
-# Sort the options using rank
-options.sort(key = lambda x : rank.rank(x, chord, tcsettings["tuning"], tcsettings["order"], tcsettings["ranks"], tcsettings["stringstarts"]))
-
-# Check the requested option is not too big
-if listpos >= len(options):
-    err(16)
 
 # figure out what the output format is
 if tcsettings["output_format"] == "TEXT":
     output.text(
-            options[listpos],
+            solution,
             name = filename,
             title = title,
             **kwgrargs,
@@ -196,7 +198,7 @@ if tcsettings["output_format"] == "TEXT":
 # TODO no options for where to put title yet
 elif tcsettings["output_format"] == "PNG":
     output.img(
-            options[listpos],
+            solution,
             name = filename,
             title = title,
             **kwgrargs,

--- a/tst/test_main.py
+++ b/tst/test_main.py
@@ -31,7 +31,6 @@ from errors import ChordError
 import interpret
 import find
 import settings
-import rank
 import output
 
 class TestInterpret:
@@ -91,45 +90,72 @@ class TestFind:
     def test_find_smallinput(self):
         # Only one way of playing Cmaj on uke neck with 3 frets
         assert find.find([0, 4, 7],
-                         [7, 0, 4, 9],
-                         3,
-                         [0, 0, 0, 0]) == [[0, 0, 0, 3]]
+                         nmute = 0,
+                         important = 0,
+                         index = 1,
+                         nfrets = 3,
+                         tuning = [7, 0, 4, 9],
+                         order = [2, 0, 1, 3],
+                         ranks = [1, 2, 3, 1, 0, 0, 0, 0, 0],
+                         stringstarts = [0, 0, 0, 0]) == [0, 0, 0, 3]
+        assert find.find.count == 1
     
     # CHECK NO CHORDS ARE PROPOSED WITH FRETS BELOW STRINGSTARTS
     def test_find_stringstarts(self):
-        options = find.find([7, 2, 9],
-                            [7, 2, 7, 11, 2],
-                            15,
-                            [5, 0, 0, 0, 0])
-        for opt in options:
+        find.find([7, 2, 9],
+                  nmute = 0,
+                  important = 0,
+                  index = 1,
+                  nfrets = 15,
+                  tuning = [7, 2, 7, 11, 2],
+                  order = [4, 0, 1, 2, 3],
+                  ranks = [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                  stringstarts = [5, 0, 0, 0, 0],
+                  keep_full_list = True)
+        for opt in find.find.full_list:
             assert opt[0] >= 5
     
     # CHECK THERE IS AN ERROR IF NO CHORDS ARE POSSIBLE
     def test_find_nooptions(self):
         with pytest.raises(ChordError):
             find.find([0, 4, 7],
-                      [7, 0, 4, 9],
-                      2,
-                      [0, 0, 0, 0])
+                      nmute = 0,
+                      important = 0,
+                      index = 1,
+                      nfrets = 2,
+                      tuning = [7, 0, 4, 9],
+                      order = [2, 0, 1, 3],
+                      ranks = [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                      stringstarts = [0, 0, 0, 0])
     
     # BASIC CHECK HIGH UP NECK
     def test_find_highneck(self):
-        assert [10, 9, 8, 8] in find.find(interpret.interpret("F"),
-                                          [7, 0, 4, 9],
-                                          12,
-                                          [0, 0, 0, 0])
-    
+        find.find(interpret.interpret("F"),
+                  nmute = 0,
+                  important = 0,
+                  index = 1,
+                  nfrets = 12,
+                  tuning = [7, 0, 4, 9],
+                  order = [2, 0, 1, 3],
+                  ranks = [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                  stringstarts = [0, 0, 0, 0],
+                  keep_full_list = True)
+        assert [10, 9, 8, 8] in find.find.full_list
+
     # CHECK THAT IF MUTE IS ALLOWED, MUTED CHORDS ARE FOUND
     def test_find_mute_01(self):
         def muteworks():
-            options = find.find([0, 4, 7],
-                                [4, 9, 2, 7, 11, 4],
-                                15,
-                                [0, 0, 0, 0, 0, 0],
-                                nmute = 2,
-                                important = 6
-                                )
-            for opt in options:
+            find.find([0, 4, 7],
+                      nmute = 2,
+                      important = 6,
+                      index = 1,
+                      nfrets = 15,
+                      tuning = [4, 9, 2, 7, 11, 4],
+                      order = [0, 1, 2, 3, 4, 5],
+                      ranks = [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                      stringstarts = [0, 0, 0, 0, 0, 0],
+                      keep_full_list = True)
+            for opt in find.find.full_list:
                 if opt[0] == -1 and opt[1] == -1:
                     return True
             return False
@@ -138,14 +164,17 @@ class TestFind:
     # CHECK THAT IF MUTE IS NOT ALLOWED, MUTED CHORDS ARE NOT FOUND
     def test_find_mute_02(self):
         def muteworks():
-            options = find.find([0, 4, 7],
-                                [4, 9, 2, 7, 11, 4],
-                                15,
-                                [0, 0, 0, 0, 0, 0],
-                                nmute = 0,
-                                important = 6
-                                )
-            for opt in options:
+            find.find([0, 4, 7],
+                      nmute = 0,
+                      important = 6,
+                      index = 1,
+                      nfrets = 15,
+                      tuning = [4, 9, 2, 7, 11, 4],
+                      order = [0, 1, 2, 3, 4, 5],
+                      ranks = [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                      stringstarts = [0, 0, 0, 0, 0, 0],
+                      keep_full_list = True)
+            for opt in find.find.full_list:
                 if opt[0] == -1 and opt[1] == -1:
                     return False
             return True
@@ -153,12 +182,33 @@ class TestFind:
     
     # CHECK THAT ONLY C'S WORKS FOR CMAJ IF ONLY 1 NOTE IS IMPORTANT
     def test_find_smallimportant(self):
-        assert [5, 0, 8, 3] in find.find([0, 4, 7],
-                                         [7, 0, 4, 9],
-                                         12,
-                                         [0, 0, 0, 0],
-                                         nmute = 0,
-                                         important = 1)
+        find.find(interpret.interpret("C"),
+                  nmute = 0,
+                  important = 1,
+                  index = 1,
+                  nfrets = 12,
+                  tuning = [7, 0, 4, 9],
+                  order = [2, 0, 1, 3],
+                  ranks = [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                  stringstarts = [0, 0, 0, 0],
+                  keep_full_list = True)
+        assert [5, 0, 8, 3] in find.find.full_list
+        
+    # CHECK THAT THE COMMON CMAJ ON UKULELE FINDS ALL 90 OPTIONS
+    def test_find_allpossibilities(self):
+        find.find(interpret.interpret("C"),
+                  nmute = 0,
+                  important = 0,
+                  index = 1,
+                  nfrets = 12,
+                  tuning = [7, 0, 4, 9],
+                  order = [2, 0, 1, 3],
+                  ranks = [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                  stringstarts = [0, 0, 0, 0])
+        assert find.find.count == 90
+    
+    # TODO maybe make a dict of lots of different counts here to test
+    # esp. with different importance and muting settings
 
 class TestRank:
     
@@ -167,40 +217,32 @@ class TestRank:
     # reasonable results for basic chords with an obvious best choice.
     # TODO change settings so the entries can be overwritten.
     def test_rank_basicuke_01(self):
-        # tests that C major is what you would expect.
+        # tests that C major is what you would expect.        
         ukesettings, _, _ = settings.get_settings(instrument_preset = "UKULELE",
                                                   ranking_preset = "UKULELE")
-        options = find.find([0, 4, 7],
-                            ukesettings["tuning"],
-                            ukesettings["nfrets"],
-                            ukesettings["stringstarts"],
-                            ukesettings["nmute"],
-                            ukesettings["important"])
-        options.sort(key = lambda x : rank.rank(x,
-                                                [0, 4, 7],
-                                                ukesettings["tuning"],
-                                                ukesettings["order"],
-                                                ukesettings["ranks"],
-                                                ukesettings["stringstarts"]))
-        assert options[0] == [0, 0, 0, 3]
+        assert find.find(interpret.interpret("C"),
+                         nmute = ukesettings["nmute"],
+                         important = ukesettings["important"],
+                         index = 1,
+                         nfrets = ukesettings["nfrets"],
+                         tuning = ukesettings["tuning"],
+                         order = ukesettings["order"],
+                         ranks = ukesettings["ranks"],
+                         stringstarts = ukesettings["stringstarts"]) == [0, 0, 0, 3]
     
     def test_rank_basicuke_02(self):
-        # tests that C major is what you would expect.
+        # tests that A minor is what you would expect.        
         ukesettings, _, _ = settings.get_settings(instrument_preset = "UKULELE",
                                                   ranking_preset = "UKULELE")
-        options = find.find([9, 4, 0],
-                            ukesettings["tuning"],
-                            ukesettings["nfrets"],
-                            ukesettings["stringstarts"],
-                            ukesettings["nmute"],
-                            ukesettings["important"])
-        options.sort(key = lambda x : rank.rank(x,
-                                                [9, 4, 0],
-                                                ukesettings["tuning"],
-                                                ukesettings["order"],
-                                                ukesettings["ranks"],
-                                                ukesettings["stringstarts"]))
-        assert options[0] == [2, 0, 0, 0]
+        assert find.find(interpret.interpret("Am"),
+                         nmute = ukesettings["nmute"],
+                         important = ukesettings["important"],
+                         index = 1,
+                         nfrets = ukesettings["nfrets"],
+                         tuning = ukesettings["tuning"],
+                         order = ukesettings["order"],
+                         ranks = ukesettings["ranks"],
+                         stringstarts = ukesettings["stringstarts"]) == [2, 0, 0, 0]
     
     # TODO test individual ranking funcs (require that new rank funcs be added
     # at end of list to avoid disrupting order of existing coeffs)


### PR DESCRIPTION
This addresses issue #8 about many-note guitar chords being noticeably slow. Thank you to @reiniscirpons for his helpful comments which have allowed some useless options which were being considered to be skipped.

The chord finding algorithm in `find.py` has been updated to do the following:

- Pre-emptively optimise by removing any notes from the end of the chord request which makes it have more notes than the number of strings.
- If the current chord attempt is missing `k` notes to cover all the important notes of the requested chord, increment the counter by enough steps that the first `k` strings have changed frets. (previously the incrementation was systematically one step). This does not catch all the dead branches - only the ones that are dead from the left side of the instrument neck. But on larger instruments this still skips a load of unnecessary computation.
- At each step, update only the values of the strings that have been changed, to minimise unnecessary computation.
- Rather than storing all possibilities then ranking, rank as you go and only store the few best options. (more of a memory-efficient solution than a time-efficient solution)

Empirical verifications suggest that this makes little difference for ukulele, but results in a 6x speedup for guitar chords containing 6 distinct notes (e.g. `C11`, `Dm11`) - down from ~7s to ~1s.